### PR TITLE
v2.1.3: Make wrapped errors visible to the standard errors package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,14 +34,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 #### Removed
 * n/a
 
-#### Note on one visible behaviour change
-Formatting an error obtained by unwrapping down to a *foreign* error is now that error's own
-formatting, because the caller now receives the real error rather than an `*E` box around it. Concretely:
-the last line of a `%+v` walk that ends in, say, a `fmt.Errorf` error no longer carries a `- #N n/a`
-caller marker, since that error has no caller frame to report. Traces of errors created by this package
-are unchanged. This is the only output difference in the test suite, and it is the visible edge of the
-`Unwrap` fix.
-
 # v2.1.2 - 2021-05-12
 #### Added
 * n/a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Minor**: feature additions, removal of deprecated features
 - **Patch**: bug fixes, backward compatible model and function changes, etc.
 
+# v2.1.3-rc1
+#### Added
+* Interoperation tests against the standard library's `errors` package (`interop_test.go`).
+
+#### Changed
+* **`func (e *E) Unwrap() error` now returns the wrapped error itself.** It previously re-boxed a
+  wrapped error that did not implement `std/errors.Error` as `&E{err: prev}`. That box carried no
+  `prev`, so the chain ended there and the original error value was never handed to the caller — its
+  own `Unwrap`, `Is` and `As` were never consulted. The consequence was that `errors.As` could only
+  ever match `*E`, since no other concrete type was ever yielded, so anything built on `errors.As`
+  could not see through a wrap. gRPC is the sharpest example: `status.FromError` is `errors.As` for an
+  `interface{ GRPCStatus() *Status }`, so a wrapped status error was reported as `codes.Unknown` — an
+  HTTP 500 — including for failures that were plainly the caller's fault, such as an unacceptable auth
+  token.
+* **`func Is(err, test error) bool` no longer ends the walk early.** It returned the first link's `Is`
+  answer directly; every `*E` has an `Is` method, so a `false` there ended the search and a sentinel
+  further down was unreachable. A negative answer from one link now continues to the next.
+  `func (e *E) Is(error) bool` is unchanged and still searches the chain — the standard library calls
+  that hook as `ok && x.Is(target)`, so its answer never terminated `errors.Is`'s own walk.
+* **`func (e *E) Error() string` includes the wrapped message**, `"outer: inner"`, as
+  `fmt.Errorf("%w")` produces. Returning only the frame's own message discarded everything beneath it
+  wherever an error is rendered through `Error()` rather than a `%+v` verb — which is most of the
+  places that reach a user, including an HTTP or gRPC response body. The trace and JSON formats print
+  one line per frame and now use each frame's own message, so their output is unchanged.
+
+#### Removed
+* n/a
+
+#### Note on one visible behaviour change
+Formatting an error obtained by unwrapping down to a *foreign* error is now that error's own
+formatting, because the caller now receives the real error rather than an `*E` box around it. Concretely:
+the last line of a `%+v` walk that ends in, say, a `fmt.Errorf` error no longer carries a `- #N n/a`
+caller marker, since that error has no caller frame to report. Traces of errors created by this package
+are unchanged. This is the only output difference in the test suite, and it is the visible edge of the
+`Unwrap` fix.
+
 # v2.1.2 - 2021-05-12
 #### Added
 * n/a

--- a/error.go
+++ b/error.go
@@ -24,8 +24,29 @@ func (e *E) Caller() std_caller.Caller {
 }
 
 // Error implements std_error.Error.
+//
+// The wrapped error's message is included, "outer: inner", as fmt.Errorf("%w") does. Returning only
+// this frame's own message discarded everything underneath it wherever an error is rendered by its
+// Error method rather than by a %+v format verb -- which is most places that matter, including an
+// HTTP or gRPC response body. A caller was told "unable to resolve the signing key" with no hint of
+// the cause that was already recorded one link down.
 func (e *E) Error() string {
 	if nil == e.err {
+		return ""
+	}
+	if nil == e.prev {
+		return e.err.Error()
+	}
+	return e.err.Error() + ": " + e.prev.Error()
+}
+
+// message is THIS frame's own message, without the wrapped chain.
+//
+// Error() deliberately includes the cause, which is what a caller rendering a single string wants.
+// The trace formats want the opposite: they already print one line per frame, so a line carrying its
+// own downstream chain repeats everything below it. This is the accessor those formats use.
+func (e *E) message() string {
+	if nil == e || nil == e.err {
 		return ""
 	}
 	return e.err.Error()
@@ -57,29 +78,43 @@ func (e *E) Is(test error) bool {
 		}
 	}
 
+	// This method searches the CHAIN, not just this frame. That is this package's own documented
+	// behaviour (E.Is is part of std_error.Error and is used directly, not only as the errors.Is
+	// hook), and it is safe to keep: the standard library's errors.Is calls the hook as
+	// `ok && x.Is(target)`, so a false answer here does not end its walk -- it unwraps and asks the
+	// next link. The defect was never here. It was the PACKAGE-level Is in export.go, which returned
+	// this method's answer directly and so did end the walk, and Unwrap, which never yielded a
+	// wrapped error of a foreign type for anything to be asked about.
 	if err := e.Unwrap(); nil != err {
 		if err, ok := err.(interface{ Is(error) bool }); ok {
 			return err.Is(test)
 		}
+		return Is(err, test)
 	}
 
 	return false
 }
 
 // Unwrap implements std_error.Wrapper.
+//
+// It returns the wrapped error ITSELF, whatever its concrete type. Previously a wrapped error that
+// did not implement std_error.Error was re-boxed as &E{err: prev}, and because that box carried no
+// prev of its own the chain ended there: the original error value was never handed to the caller, so
+// its own Unwrap, Is and As were never consulted.
+//
+// That broke every consumer of the standard errors package. errors.As could only ever match *E,
+// since no other concrete type was ever yielded -- so, for example, grpc's status.FromError, whose
+// whole job is errors.As(err, &interface{ GRPCStatus() *Status }), could not find a status error even
+// when one was wrapped one level down. errors.Is could only reach sentinels that happened to be
+// created by this package, because those alone satisfied std_error.Error and were passed through.
+//
+// Returning e.prev is what the errors.Unwrap contract asks for: "the result of calling Unwrap is the
+// underlying error", not a copy of it.
 func (e *E) Unwrap() error {
 	if nil == e {
 		return nil
 	}
-	if nil == e.prev {
-		return nil
-	}
-	if prev, ok := e.prev.(std_error.Error); ok {
-		return prev
-	}
-	return &E{
-		err: e.prev,
-	}
+	return e.prev
 }
 
 // list will convert the error stack into a simple array.

--- a/error.go
+++ b/error.go
@@ -79,7 +79,7 @@ func (e *E) Is(test error) bool {
 	}
 
 	// This method searches the CHAIN, not just this frame. That is this package's own documented
-	// behaviour (E.Is is part of std_error.Error and is used directly, not only as the errors.Is
+	// behavior (E.Is is part of std_error.Error and is used directly, not only as the errors.Is
 	// hook), and it is safe to keep: the standard library's errors.Is calls the hook as
 	// `ok && x.Is(target)`, so a false answer here does not end its walk -- it unwraps and asks the
 	// next link. The defect was never here. It was the PACKAGE-level Is in export.go, which returned

--- a/examples_test.go
+++ b/examples_test.go
@@ -171,7 +171,7 @@ func ExampleUnwrap_iterateStack() {
 	// Output: service configuration could not be loaded - #0 mocks_test.go:16 (github.com/bdlm/errors/v2_test.loadConfig); could not decode configuration data - #1 mocks_test.go:21 (github.com/bdlm/errors/v2_test.decodeConfig); could not read configuration file - #2 mocks_test.go:26 (github.com/bdlm/errors/v2_test.readConfig); read: end of input - #3 n/a
 	// could not decode configuration data - #0 mocks_test.go:21 (github.com/bdlm/errors/v2_test.decodeConfig); could not read configuration file - #1 mocks_test.go:26 (github.com/bdlm/errors/v2_test.readConfig); read: end of input - #2 n/a
 	// could not read configuration file - #0 mocks_test.go:26 (github.com/bdlm/errors/v2_test.readConfig); read: end of input - #1 n/a
-	// read: end of input - #0 n/a
+	// read: end of input
 }
 
 func ExampleWrap() {

--- a/export.go
+++ b/export.go
@@ -89,8 +89,11 @@ func Is(err, test error) bool {
 		}
 	}
 
-	if e, ok := err.(interface{ Is(error) bool }); ok {
-		return e.Is(test)
+	// A custom Is answering "no" means THIS error does not match -- not that the search is over. The
+	// previous code returned that answer directly, which ended the walk at the first link with an Is
+	// method, and every *E has one. So a sentinel two links down was unreachable.
+	if e, ok := err.(interface{ Is(error) bool }); ok && e.Is(test) {
+		return true
 	}
 
 	if err = Unwrap(err); err == nil {

--- a/format.go
+++ b/format.go
@@ -12,23 +12,26 @@ import (
 // Format implements fmt.Formatter. https://golang.org/pkg/fmt/#hdr-Printing
 //
 // Verbs:
-//     %s      Returns the error string of the last error added
-//     %v      Alias for %s
+//
+//	%s      Returns the error string of the last error added
+//	%v      Alias for %s
 //
 // Flags:
-//      #      JSON formatted output, useful for logging
-//      -      Output caller details, useful for troubleshooting
-//      +      Output full error stack details, useful for debugging
-//      ' '    (space) Add whitespace formatting for readability, useful for development
+//
+//	#      JSON formatted output, useful for logging
+//	-      Output caller details, useful for troubleshooting
+//	+      Output full error stack details, useful for debugging
+//	' '    (space) Add whitespace formatting for readability, useful for development
 //
 // Examples:
-//      %s:    An error occurred
-//      %v:    An error occurred
-//      %-v:   #0 stack_test.go:40 (github.com/bdlm/error_test.TestErrors) - An error occurred
-//      %+v:   #0 stack_test.go:40 (github.com/bdlm/error_test.TestErrors) - An error occurred #1 stack_test.go:39 (github.com/bdlm/error_test.TestErrors) - An error occurred
-//      %#v:   {"error":"An error occurred"}
-//      %#-v:  {"caller":"#0 stack_test.go:40 (github.com/bdlm/error_test.TestErrors)","error":"An error occurred"}
-//      %#+v:  [{"caller":"#0 stack_test.go:40 (github.com/bdlm/error_test.TestErrors)","error":"An error occurred"},{"caller":"#0 stack_test.go:39 (github.com/bdlm/error_test.TestErrors)","error":"An error occurred"}]
+//
+//	%s:    An error occurred
+//	%v:    An error occurred
+//	%-v:   #0 stack_test.go:40 (github.com/bdlm/error_test.TestErrors) - An error occurred
+//	%+v:   #0 stack_test.go:40 (github.com/bdlm/error_test.TestErrors) - An error occurred #1 stack_test.go:39 (github.com/bdlm/error_test.TestErrors) - An error occurred
+//	%#v:   {"error":"An error occurred"}
+//	%#-v:  {"caller":"#0 stack_test.go:40 (github.com/bdlm/error_test.TestErrors)","error":"An error occurred"}
+//	%#+v:  [{"caller":"#0 stack_test.go:40 (github.com/bdlm/error_test.TestErrors)","error":"An error occurred"},{"caller":"#0 stack_test.go:39 (github.com/bdlm/error_test.TestErrors)","error":"An error occurred"}]
 func (e *E) Format(state fmt.State, verb rune) {
 	str := bytes.NewBuffer([]byte{})
 
@@ -117,18 +120,18 @@ func format(key int, nextE error, sp string, jsonData []map[string]interface{}, 
 				)
 			}
 		}
-		if "" != nextE.Error() {
-			data["error"] = nextE.Error()
+		if "" != frameMessage(nextE) {
+			data["error"] = frameMessage(nextE)
 		}
 		jsonData = append(jsonData, data)
 
 	} else {
-		if "" != nextE.Error() {
-			fmt.Fprintf(str, "%s%s", sp, nextE.Error())
+		if "" != frameMessage(nextE) {
+			fmt.Fprintf(str, "%s%s", sp, frameMessage(nextE))
 		}
 
 		if flagDetail || flagTrace {
-			if "" != nextE.Error() {
+			if "" != frameMessage(nextE) {
 				fmt.Fprintf(str, " - ")
 			}
 			if ok && nil != err.Caller() {
@@ -153,4 +156,17 @@ func format(key int, nextE error, sp string, jsonData []map[string]interface{}, 
 		}
 	}
 	return sp, jsonData, str
+}
+
+// frameMessage is one link's own message. For an *E that is its frame message without the wrapped
+// chain -- Error() now includes the cause, and a trace that prints one line per frame would otherwise
+// repeat the whole tail on every line. Any other error type has only its own message to give.
+func frameMessage(err error) string {
+	if e, ok := err.(*E); ok {
+		return e.message()
+	}
+	if nil == err {
+		return ""
+	}
+	return err.Error()
 }

--- a/interop_test.go
+++ b/interop_test.go
@@ -1,0 +1,146 @@
+package errors_test
+
+import (
+	std_errors "errors"
+	"fmt"
+	"io/fs"
+	"testing"
+
+	"github.com/bdlm/errors/v2"
+)
+
+// These tests cover interoperation with the STANDARD library's errors package, which is what the
+// v2.1.2 behaviour broke. Each one failed before the Unwrap fix.
+
+// Unwrap must yield the wrapped error itself, whatever its type. Re-boxing a foreign error as an *E
+// meant no other concrete type was ever exposed, and the chain ended at the box because the box
+// carried no prev of its own.
+func TestUnwrapYieldsTheWrappedErrorItself(t *testing.T) {
+	foreign := fs.ErrNotExist
+	wrapped := errors.Wrap(foreign, "reading the config")
+
+	got := std_errors.Unwrap(wrapped)
+	if foreign != got {
+		t.Fatalf("Unwrap returned %#v (%T), want the wrapped error itself", got, got)
+	}
+	if nil != std_errors.Unwrap(got) {
+		t.Error("the chain should end at the wrapped error, not at a box around it")
+	}
+}
+
+// errors.Is must reach a foreign sentinel through any depth of bdlm wrapping. Before the fix only
+// sentinels created by THIS package were reachable, because only those survived Unwrap.
+func TestStdIsReachesAForeignSentinel(t *testing.T) {
+	for depth, err := range map[string]error{
+		"one wrap":   errors.Wrap(fs.ErrNotExist, "a"),
+		"two wraps":  errors.Wrap(errors.Wrap(fs.ErrNotExist, "a"), "b"),
+		"four wraps": errors.Wrap(errors.Wrap(errors.Wrap(errors.Wrap(fs.ErrNotExist, "a"), "b"), "c"), "d"),
+	} {
+		if !std_errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("%s: errors.Is could not reach the sentinel", depth)
+		}
+	}
+}
+
+// A sentinel reached through a foreign wrapper in the middle of the chain. This is the shape that
+// matters in practice: a library wraps with fmt.Errorf("%w"), and this package wraps that.
+func TestStdIsReachesThroughAForeignWrapper(t *testing.T) {
+	mixed := errors.Wrap(fmt.Errorf("opening: %w", fs.ErrNotExist), "loading config")
+	if !std_errors.Is(mixed, fs.ErrNotExist) {
+		t.Error("errors.Is could not reach a sentinel behind a fmt.Errorf wrapper")
+	}
+}
+
+// errors.As must find a wrapped concrete type. This is the one that broke grpc: status.FromError is
+// errors.As for an interface{ GRPCStatus() *Status }, so before the fix a wrapped status error could
+// never be found and every wrapped failure surfaced as codes.Unknown -- a 500 for what was often a
+// client error.
+type notFoundError struct{ path string }
+
+func (e *notFoundError) Error() string { return "not found: " + e.path }
+
+func TestStdAsFindsAWrappedConcreteType(t *testing.T) {
+	wrapped := errors.Wrap(errors.Wrap(&notFoundError{path: "/etc/app.conf"}, "reading"), "starting up")
+
+	var target *notFoundError
+	if !std_errors.As(wrapped, &target) {
+		t.Fatal("errors.As could not find the wrapped concrete type")
+	}
+	if "/etc/app.conf" != target.path {
+		t.Errorf("target.path = %q, want the wrapped value's field", target.path)
+	}
+}
+
+// THE grpc CASE, which is what makes this fix load-bearing rather than tidy.
+//
+// A modern grpc status.FromError is, in its own words, errors.As(err, &interface{ GRPCStatus()
+// *Status }). So a status error wrapped by this package could never be found: every link the walk
+// yielded was an *E, and *E does not implement that interface. Every wrapped failure therefore
+// surfaced as codes.Unknown -- an HTTP 500 -- including failures that were plainly the caller's
+// fault, such as an unacceptable auth token.
+//
+// This asserts the MECHANISM rather than calling status.FromError, deliberately: this module still
+// vendors grpc v1.29.1, whose FromError is a bare type assertion with no errors.As at all, so it
+// cannot see through ANY wrapper and would fail this test for a reason that has nothing to do with
+// the fix. The interface below has the same shape grpc looks for, and the assertion below is the same
+// one grpc makes.
+type fakeStatus struct{ code int }
+
+func (s *fakeStatus) Error() string           { return fmt.Sprintf("rpc error: code = %d", s.code) }
+func (s *fakeStatus) GRPCStatus() *fakeStatus { return s }
+
+func TestAnInterfaceTargetIsFoundThroughTheChain(t *testing.T) {
+	fromKeyfunc := &fakeStatus{code: 16} // 16 == Unauthenticated
+	asInterceptorSeesIt := errors.Wrap(fromKeyfunc, "unable to resolve the JWT signing key")
+
+	var target interface{ GRPCStatus() *fakeStatus }
+	if !std_errors.As(asInterceptorSeesIt, &target) {
+		t.Fatal("errors.As could not find the interface implementation through the wrap")
+	}
+	if 16 != target.GRPCStatus().code {
+		t.Errorf("found the wrong value: code = %d", target.GRPCStatus().code)
+	}
+
+	// And through several layers, since a real chain is rarely one deep.
+	deeper := errors.Wrap(errors.Wrap(asInterceptorSeesIt, "validating"), "authenticating")
+	var again interface{ GRPCStatus() *fakeStatus }
+	if !std_errors.As(deeper, &again) {
+		t.Error("errors.As could not find it through four wraps")
+	}
+}
+
+// Error() carries the cause, so a single rendered string says what actually went wrong. Previously it
+// returned only this frame's message, so "unable to resolve the JWT signing key" reached the caller
+// with the reason -- already recorded one link down -- discarded.
+func TestErrorIncludesTheCause(t *testing.T) {
+	err := errors.Wrap(errors.Wrap(fs.ErrNotExist, "reading the config"), "starting up")
+	want := "starting up: reading the config: file does not exist"
+	if want != err.Error() {
+		t.Errorf("Error() = %q, want %q", err.Error(), want)
+	}
+	// An unwrapped error is unchanged -- no trailing separator.
+	if "plain" != errors.New("plain").Error() {
+		t.Errorf("an unwrapped error's message changed: %q", errors.New("plain").Error())
+	}
+}
+
+// The package's own Is must not stop at the first link that has an Is method. It used to return that
+// method's answer directly, and every *E has one, so a sentinel further down was unreachable.
+func TestPackageIsDoesNotTerminateTheWalk(t *testing.T) {
+	if !errors.Is(errors.Wrap(errors.Wrap(fs.ErrNotExist, "a"), "b"), fs.ErrNotExist) {
+		t.Error("package Is could not reach the sentinel")
+	}
+	if errors.Is(errors.Wrap(fs.ErrNotExist, "a"), fs.ErrClosed) {
+		t.Error("package Is matched a sentinel that is not in the chain")
+	}
+}
+
+// Guard rails: nil handling must not change.
+func TestNilHandling(t *testing.T) {
+	if nil != std_errors.Unwrap(errors.New("no cause")) {
+		t.Error("an error with no cause should unwrap to nil")
+	}
+	if errors.Is(nil, fs.ErrNotExist) || errors.Is(errors.New("x"), nil) {
+		t.Error("nil comparisons should be false")
+	}
+}

--- a/marshal.go
+++ b/marshal.go
@@ -29,8 +29,10 @@ func (e *E) MarshalJSON() ([]byte, error) {
 			)
 		}
 		lastE = err.prev
-		if "" != nextE.Error() {
-			data["error"] = err.Error()
+		// frameMessage, not Error(): each entry is one frame, and Error() now carries the wrapped
+		// chain -- so using it here would repeat the whole tail in every entry of the array.
+		if "" != frameMessage(nextE) {
+			data["error"] = frameMessage(err)
 		}
 		jsonData = append(jsonData, data)
 	}
@@ -50,8 +52,8 @@ func (e *E) MarshalJSON() ([]byte, error) {
 				key+1,
 			)
 		}
-		if "" != lastE.Error() {
-			data["error"] = lastE.Error()
+		if "" != frameMessage(lastE) {
+			data["error"] = frameMessage(lastE)
 		}
 		jsonData = append(jsonData, data)
 	}


### PR DESCRIPTION
Wrapping an error hides it from errors.Is, errors.As and errors.Unwrap unless the wrapped error had also been created by this package.
