### PR TITLE
v2.1.4: Traverse multi-errors in Is and As

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Minor**: feature additions, removal of deprecated features
 - **Patch**: bug fixes, backward compatible model and function changes, etc.
 
-# v2.1.4
+# v2.1.4 - 2026-08-20
 #### Fixed
 * **`Is` and `As` now traverse multi-errors.** An error may wrap several causes — `errors.Join`, or
   `fmt.Errorf` with more than one `%w` — and those implement `Unwrap() []error`, which the
-  single-error `Unwrap` cannot express: it returns `nil` for them. Both walks therefore terminated at
-  the join and every cause beneath it was unreachable, so `Is` answered `false` for a sentinel sitting
-  *directly inside* the error it was handed, unwrapped. `golang-jwt` joins its sentinels, so no `jwt`
-  error was matchable at all and callers classifying on `jwt.ErrTokenMalformed` saw a caller's bad
-  credential fall through to a 5xx. Both now branch over `Unwrap() []error` and search the whole tree,
-  matching the standard library.
+  single-error `Unwrap` cannot express.
 * `Unwrap` still returns `nil` for a multi-error, as `std/errors.Unwrap` does — there is no single
   previous error to return. This is now documented rather than implicit; callers walking a chain
   themselves must branch on `Unwrap() []error`.
 
-# v2.1.3-rc1
+# v2.1.3 - 2026-08-20
 #### Added
 * Interoperation tests against the standard library's `errors` package (`interop_test.go`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Minor**: feature additions, removal of deprecated features
 - **Patch**: bug fixes, backward compatible model and function changes, etc.
 
+# v2.1.4
+#### Fixed
+* **`Is` and `As` now traverse multi-errors.** An error may wrap several causes — `errors.Join`, or
+  `fmt.Errorf` with more than one `%w` — and those implement `Unwrap() []error`, which the
+  single-error `Unwrap` cannot express: it returns `nil` for them. Both walks therefore terminated at
+  the join and every cause beneath it was unreachable, so `Is` answered `false` for a sentinel sitting
+  *directly inside* the error it was handed, unwrapped. `golang-jwt` joins its sentinels, so no `jwt`
+  error was matchable at all and callers classifying on `jwt.ErrTokenMalformed` saw a caller's bad
+  credential fall through to a 5xx. Both now branch over `Unwrap() []error` and search the whole tree,
+  matching the standard library.
+* `Unwrap` still returns `nil` for a multi-error, as `std/errors.Unwrap` does — there is no single
+  previous error to return. This is now documented rather than implicit; callers walking a chain
+  themselves must branch on `Unwrap() []error`.
+
 # v2.1.3-rc1
 #### Added
 * Interoperation tests against the standard library's `errors` package (`interop_test.go`).

--- a/export.go
+++ b/export.go
@@ -37,6 +37,16 @@ func As(err, test error) error {
 		if e, ok := err.(interface{ As(error) error }); ok {
 			return e.As(test)
 		}
+		// Same multi-error branch as Is, for the same reason: Unwrap cannot express Unwrap() []error,
+		// so the walk would terminate at a join and miss every cause below it.
+		if multi, ok := err.(interface{ Unwrap() []error }); ok {
+			for _, branch := range multi.Unwrap() {
+				if found := As(branch, test); nil != found {
+					return found
+				}
+			}
+			return nil
+		}
 		err = Unwrap(err)
 	}
 
@@ -94,6 +104,22 @@ func Is(err, test error) bool {
 	// method, and every *E has one. So a sentinel two links down was unreachable.
 	if e, ok := err.(interface{ Is(error) bool }); ok && e.Is(test) {
 		return true
+	}
+
+	// An error may wrap SEVERAL causes -- errors.Join, or fmt.Errorf with more than one %w. Those
+	// implement Unwrap() []error, which the single-error Unwrap below cannot express: it returns nil
+	// for them, so without this branch the walk stops dead at the join and every cause underneath is
+	// unreachable. That made Is answer false for a joined sentinel even when the join was the error
+	// passed in, unwrapped -- golang-jwt joins its sentinels, so no jwt error was ever matchable.
+	//
+	// The whole tree is searched, not just the first branch, which is what the standard library does.
+	if multi, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, branch := range multi.Unwrap() {
+			if Is(branch, test) {
+				return true
+			}
+		}
+		return false
 	}
 
 	if err = Unwrap(err); err == nil {
@@ -161,6 +187,10 @@ func Track(e error) *E {
 }
 
 // Unwrap returns the previous error.
+//
+// A multi-error -- one implementing Unwrap() []error -- has no single previous error, so this
+// returns nil for it, exactly as the standard library's errors.Unwrap does. Callers that walk a
+// chain must branch on Unwrap() []error themselves; Is and As do.
 func Unwrap(err error) error {
 	if e, ok := err.(interface{ Unwrap() error }); ok {
 		return e.Unwrap()

--- a/multierror_test.go
+++ b/multierror_test.go
@@ -1,0 +1,86 @@
+package errors_test
+
+import (
+	std_errors "errors"
+	"fmt"
+	"testing"
+
+	"github.com/bdlm/errors/v2"
+)
+
+var (
+	errWanted = std_errors.New("the sentinel we are looking for")
+	errOther  = std_errors.New("an unrelated cause")
+)
+
+// customErr uses a VALUE receiver so that *customErr is a pointer whose element type implements
+// error, which is the shape bdlm's As(err, test error) requires of its target.
+type customErr struct{ msg string }
+
+func (c customErr) Error() string { return c.msg }
+
+// TestIsTraversesMultiErrors covers errors that wrap SEVERAL causes -- errors.Join and fmt.Errorf
+// with more than one %w. They implement Unwrap() []error, which the single-error Unwrap cannot
+// express, so before this was handled the walk terminated at the join and Is answered false for a
+// sentinel sitting directly inside it.
+//
+// This is not a hypothetical shape: golang-jwt joins its sentinels, so a parser rejection is a
+// *fmt.wrapErrors and NO jwt error could be matched -- callers saw a credential rejection fall
+// through to a 5xx.
+func TestIsTraversesMultiErrors(t *testing.T) {
+	for name, err := range map[string]error{
+		"join, sentinel first":     std_errors.Join(errWanted, errOther),
+		"join, sentinel last":      std_errors.Join(errOther, errWanted),
+		"fmt.Errorf two %w":        fmt.Errorf("a: %w, b: %w", errOther, errWanted),
+		"wrapped join":             errors.Wrap(std_errors.Join(errOther, errWanted), "context"),
+		"twice-wrapped join":       errors.Wrap(errors.Wrap(std_errors.Join(errOther, errWanted), "inner"), "outer"),
+		"join of a wrapped2 chain": std_errors.Join(errOther, errors.Wrap(errWanted, "context")),
+		"nested joins":             std_errors.Join(errOther, std_errors.Join(errOther, errWanted)),
+	} {
+		if !errors.Is(err, errWanted) {
+			t.Errorf("%s: Is = false, want true", name)
+		}
+		// The standard library is the reference implementation; agree with it.
+		if std_errors.Is(err, errWanted) != errors.Is(err, errWanted) {
+			t.Errorf("%s: disagrees with std_errors.Is", name)
+		}
+	}
+}
+
+// TestIsSearchesEveryBranch: a match in a later branch must still be found, and a sentinel that is
+// genuinely absent must still report false -- the search must not become indiscriminate.
+func TestIsSearchesEveryBranch(t *testing.T) {
+	absent := std_errors.New("never wrapped")
+	for name, err := range map[string]error{
+		"join without it":    std_errors.Join(errOther, errWanted),
+		"wrapped join":       errors.Wrap(std_errors.Join(errOther, errWanted), "context"),
+		"deep nested branch": std_errors.Join(errOther, std_errors.Join(errOther, errors.Wrap(errWanted, "deep"))),
+	} {
+		if errors.Is(err, absent) {
+			t.Errorf("%s: Is(absent) = true, want false", name)
+		}
+	}
+	if errors.Is(nil, errWanted) || errors.Is(errWanted, nil) {
+		t.Error("a nil operand must never match")
+	}
+}
+
+// TestAsTraversesMultiErrors: As had the same defect from the same cause.
+func TestAsTraversesMultiErrors(t *testing.T) {
+	cause := customErr{msg: "concrete cause"}
+	for name, err := range map[string]error{
+		"join":         std_errors.Join(errOther, cause),
+		"wrapped join": errors.Wrap(std_errors.Join(errOther, cause), "context"),
+		"nested joins": std_errors.Join(errOther, std_errors.Join(errOther, cause)),
+	} {
+		var reference customErr
+		if !std_errors.As(err, &reference) {
+			t.Fatalf("%s: premise broken, std_errors.As cannot find it either", name)
+		}
+
+		found := &customErr{}
+		if got := errors.As(err, found); nil == got || cause.msg != found.msg {
+			t.Errorf("%s: As did not reach the concrete cause (got %v, found %q)", name, got, found.msg)
+		}
+	}
+}


### PR DESCRIPTION
An error may wrap several causes -- errors.Join, or fmt.Errorf with more than one %w. Those implement Unwrap() []error, which the single-error Unwrap cannot express: it returns nil for them. Both walks therefore stopped at the join, making every cause beneath it unreachable.

The visible effect was worse than "deep sentinels are missed": Is answered false for a sentinel sitting directly inside the error it was handed, not wrapped at all, because the join itself was the terminating link. golang-jwt joins its sentinels, so a parser rejection arrives as *fmt.wrapErrors and NO jwt error could be matched -- a consumer classifying on jwt.ErrTokenMalformed to return 401 got false every time and the caller's bad credential fell through as a 5xx.

Both functions now branch on Unwrap() []error and search the whole tree rather than the first branch, which is what the standard library does. The new tests assert agreement with std_errors.Is case by case, and fail against the unwrapped code -- verified by reverting the fix and re-running.

Unwrap itself is unchanged and still returns nil for a multi-error, matching std/errors.Unwrap: there is no single previous error to return. That is now documented rather than implicit.

This defect predates v2.1.3; it is not a regression from that release.