### PR TITLE
v2.2.0: Match the standard library's As signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Minor**: feature additions, removal of deprecated features
 - **Patch**: bug fixes, backward compatible model and function changes, etc.
 
+# v2.1.5
+#### Fixed
+Eight defects, all found by a new contract test suite (`contract_test.go`) organised by obligation
+rather than by function. Coverage 95.9%, race-clean.
+
+* **Panics on nil.** `doc.go` promises every method works with nil values; four did not.
+  `(*E).Error`, `(*E).Is` and `(*E).MarshalJSON` dereferenced a nil receiver, and `(*E).Is` also
+  panicked whenever the frame carried no annotation of its own — `reflect.TypeOf(nil)` returns a
+  NIL `reflect.Type`, and calling `Comparable` on that panics rather than answering false. The
+  package-level `Is` had the same flaw. Both now share a `comparableErrors` helper.
+* **`New` and `Wrap` corrupted any message containing a percent sign.** Both passed the message
+  through `fmt.Errorf`, so `New("100% complete")` produced `"100%!c(MISSING)omplete"` and
+  `"disk usage at 95%"` produced `"...95%!(NOVERB)"`. A message is now stored verbatim; only
+  `Errorf`, and `Wrap` when given arguments, formats.
+* **`MarshalJSON` panicked on a foreign wrapper in the chain.** `list()` includes any error
+  implementing `Unwrap() error`, so a `fmt.Errorf("%w")` link reached an unguarded type assertion
+  and a nil field read. Marshalling an error must never panic — it runs while something is already
+  failing.
+* **`Trace` severed the chain.** It held the wrapped error in the annotation slot and left `prev`
+  nil, so `Unwrap` returned nothing and no sentinel below a trace was reachable. The error is now
+  on the chain, and a frame with no message of its own renders transparently.
+* **`Track` severed the chain for anything that was not already an `*E`.** `prev` came from a
+  synthetic box whose own `prev` was nil, so a `fmt.Errorf("%w")` wrapper, a joined error, or any
+  foreign wrapping type lost everything beneath it.
+* **`Is` could find what `As` could not.** `WrapE`'s annotation is not on the `Unwrap` chain, and
+  `Is` special-cased it while `As` did not — so which function you reached for changed the answer.
+  `(*E)` now implements the standard `As(interface{}) bool` hook, and the package-level `As`
+  searches the same slot.
+
+#### Documentation
+* `doc.go` documented `errors.Has`, which does not exist; `Is` searches the whole chain, which is
+  what that section described. It also showed `errors.Wrap(err, err2)`, which does not compile —
+  `Wrap` takes a message string, so wrapping with an error is `WrapE`.
+* Stated the two guarantees now covered by tests: nothing panics for any combination of nil
+  arguments and nil receivers, and `Is`/`As` agree with the standard library on every chain shape.
+
 # v2.1.4 - 2026-08-20
 #### Fixed
 * **`Is` and `As` now traverse multi-errors.** An error may wrap several causes — `errors.Join`, or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Minor**: feature additions, removal of deprecated features
 - **Patch**: bug fixes, backward compatible model and function changes, etc.
 
-# v2.1.5
+# v2.2.0 - 2026-08-21
+#### Changed
+* **`As` now matches the standard library's signature**, `As(err error, target interface{}) bool`,
+  replacing `As(err, test error) error`.
+
+  The old form required the target to satisfy `error`, which had two consequences. A caller could
+  not ask for a bare interface type at all — `&interface{ GRPCStatus() *Status }{}` is not an
+  `error` — which is the most common real question to ask of a chain. And for concrete types the
+  target's receiver kind leaked into the call: a type with a pointer receiver could not be asked
+  for, so callers picked value receivers to make the call compile rather than because the type
+  wanted one.
+
+  It also meant the package's own helper did not match the library it aims to implement, so code
+  moving between `errors.As` and `bdlm/errors.As` had to change shape as well as import path.
+
+  **Migration.** `if found := errors.As(err, target); nil != found { ... }` becomes
+  `if errors.As(err, &target) { ... }`, with `target` declared as the type or interface being
+  sought. Note the address-of: the standard library takes a pointer to the target.
+
+  As now **panics** on a target that is not a non-nil pointer to an error-implementing type or to
+  an interface, again matching the standard library. An unusable target cannot match anything, so
+  answering "not found" would hide a call-site mistake in precisely the paths that are hardest to
+  observe. A nil *error* is still an ordinary `false`.
+
+  The `As(interface{}) bool` hook on `*E` is unchanged; the old `As(error) error` hook shape is no
+  longer consulted.
+
 #### Fixed
 Eight defects, all found by a new contract test suite (`contract_test.go`) organised by obligation
 rather than by function. Coverage 95.9%, race-clean.

--- a/contract_test.go
+++ b/contract_test.go
@@ -34,13 +34,9 @@ type custom struct{ msg string }
 
 func (c *custom) Error() string { return c.msg }
 
-// valueErr uses a VALUE receiver, so *valueErr is a pointer whose element implements error --
-// the shape bdlm's As(err, test error) requires of its target, and one the standard library's
-// As(err, any) accepts too. It exists so the two can be compared on identical input.
-//
-// Worth noting on its own: bdlm's As signature differs from the standard library's
-// (As(err, test error) error vs As(err error, target any) bool), which is why a target type has to
-// be chosen with both in mind.
+// valueErr uses a VALUE receiver, and *custom below uses a pointer receiver. Both shapes are
+// exercised because As must handle either, and because a target's receiver kind used to constrain
+// whether it could be asked for at all.
 type valueErr struct{ msg string }
 
 func (v valueErr) Error() string { return v.msg }
@@ -59,33 +55,33 @@ func TestNilSafety(t *testing.T) {
 	var nilE *errors.E
 
 	cases := map[string]func(){
-		"New empty":            func() { _ = errors.New("") },
-		"Errorf empty":         func() { _ = errors.Errorf("") },
-		"Wrap nil":             func() { _ = errors.Wrap(nil, "msg") },
-		"Wrap nil empty msg":   func() { _ = errors.Wrap(nil, "") },
-		"WrapE nil nil":        func() { _ = errors.WrapE(nil, nil) },
-		"WrapE err nil":        func() { _ = errors.WrapE(sentinel, nil) },
-		"WrapE nil err":        func() { _ = errors.WrapE(nil, sentinel) },
-		"Unwrap nil":           func() { _ = errors.Unwrap(nil) },
-		"Is nil nil":           func() { _ = errors.Is(nil, nil) },
-		"Is nil target":        func() { _ = errors.Is(sentinel, nil) },
-		"Is nil err":           func() { _ = errors.Is(nil, sentinel) },
-		"As nil nil":           func() { _ = errors.As(nil, nil) },
-		"As nil err":           func() { _ = errors.As(nil, sentinel) },
-		"Caller nil":           func() { _ = errors.Caller(nil) },
-		"Trace nil":            func() { _ = errors.Trace(nil) },
-		"Track nil":            func() { _ = errors.Track(nil) },
-		"nil E Error":          func() { _ = nilE.Error() },
-		"nil E Unwrap":         func() { _ = nilE.Unwrap() },
-		"nil E Caller":         func() { _ = nilE.Caller() },
-		"nil E Is":             func() { _ = nilE.Is(sentinel) },
-		"nil E MarshalJSON":    func() { _, _ = nilE.MarshalJSON() },
-		"nil E format %v":      func() { _ = fmt.Sprintf("%v", nilE) },
-		"nil E format %+v":     func() { _ = fmt.Sprintf("%+v", nilE) },
-		"nil E format %#v":     func() { _ = fmt.Sprintf("%#v", nilE) },
-		"WrapE nil err Error":  func() { _ = errors.WrapE(sentinel, nil).Error() },
-		"WrapE nil err Is":     func() { _ = errors.WrapE(sentinel, nil).Is(sentinel) },
-		"WrapE nil err format": func() { _ = fmt.Sprintf("%+v", errors.WrapE(sentinel, nil)) },
+		"New empty":              func() { _ = errors.New("") },
+		"Errorf empty":           func() { _ = errors.Errorf("") },
+		"Wrap nil":               func() { _ = errors.Wrap(nil, "msg") },
+		"Wrap nil empty msg":     func() { _ = errors.Wrap(nil, "") },
+		"WrapE nil nil":          func() { _ = errors.WrapE(nil, nil) },
+		"WrapE err nil":          func() { _ = errors.WrapE(sentinel, nil) },
+		"WrapE nil err":          func() { _ = errors.WrapE(nil, sentinel) },
+		"Unwrap nil":             func() { _ = errors.Unwrap(nil) },
+		"Is nil nil":             func() { _ = errors.Is(nil, nil) },
+		"Is nil target":          func() { _ = errors.Is(sentinel, nil) },
+		"Is nil err":             func() { _ = errors.Is(nil, sentinel) },
+		"As nil err, nil target": func() { _ = errors.As(nil, nil) },
+		"As nil err, bad target": func() { _ = errors.As(nil, sentinel) },
+		"Caller nil":             func() { _ = errors.Caller(nil) },
+		"Trace nil":              func() { _ = errors.Trace(nil) },
+		"Track nil":              func() { _ = errors.Track(nil) },
+		"nil E Error":            func() { _ = nilE.Error() },
+		"nil E Unwrap":           func() { _ = nilE.Unwrap() },
+		"nil E Caller":           func() { _ = nilE.Caller() },
+		"nil E Is":               func() { _ = nilE.Is(sentinel) },
+		"nil E MarshalJSON":      func() { _, _ = nilE.MarshalJSON() },
+		"nil E format %v":        func() { _ = fmt.Sprintf("%v", nilE) },
+		"nil E format %+v":       func() { _ = fmt.Sprintf("%+v", nilE) },
+		"nil E format %#v":       func() { _ = fmt.Sprintf("%#v", nilE) },
+		"WrapE nil err Error":    func() { _ = errors.WrapE(sentinel, nil).Error() },
+		"WrapE nil err Is":       func() { _ = errors.WrapE(sentinel, nil).Is(sentinel) },
+		"WrapE nil err format":   func() { _ = fmt.Sprintf("%+v", errors.WrapE(sentinel, nil)) },
 	}
 	for name, call := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -267,19 +263,56 @@ func TestAsTargets(t *testing.T) {
 	}
 }
 
-// TestAsRejectsInvalidTargets: the package's own As must not panic on a target the standard
-// library would reject outright.
-func TestAsRejectsInvalidTargets(t *testing.T) {
-	defer func() {
-		if r := recover(); nil != r {
-			t.Fatalf("panicked on an invalid target: %v", r)
-		}
-	}()
-	if nil != errors.As(errors.New("x"), nil) {
-		t.Error("As with a nil target should find nothing")
+// TestAsPanicsOnUnusableTargets matches the standard library exactly, and deliberately so: an
+// unusable target is a mistake at the call site, and returning false for it would hide the mistake
+// in the code paths that are hardest to observe. Silently answering "not found" for a target that
+// could never match anything is worse than crashing during development.
+func TestAsPanicsOnUnusableTargets(t *testing.T) {
+	notAPointer := 42
+	cases := map[string]interface{}{
+		"nil target":                  nil,
+		"non-pointer":                 sentinel,
+		"pointer to a non-error type": &notAPointer,
+		"typed nil pointer":           (*custom)(nil),
 	}
-	if nil != errors.As(errors.New("x"), sentinel) {
-		t.Error("As with a non-pointer target should find nothing")
+	for name, target := range cases {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); nil == r {
+					t.Error("did not panic on an unusable target")
+				}
+			}()
+			errors.As(errors.New("x"), target)
+		})
+	}
+}
+
+// TestAsWithANilErrorIsFalseNotAPanic: a nil error is a normal runtime condition, unlike a bad
+// target, so it must be answered rather than punished. The standard library draws the same line.
+func TestAsWithANilErrorIsFalseNotAPanic(t *testing.T) {
+	var target *custom
+	if errors.As(nil, &target) {
+		t.Error("As(nil, ...) reported a match")
+	}
+}
+
+// TestAsFindsInterfaceTargets: the old error-typed signature could not express this at all, since
+// an interface pointer does not itself satisfy error. It is the common real case -- asking whether
+// anything in the chain implements some behaviour.
+func TestAsFindsInterfaceTargets(t *testing.T) {
+	chain := errors.Wrap(errors.Wrap(&falseIs{inner: sentinel}, "a"), "b")
+
+	var unwrapper interface{ Unwrap() error }
+	if !errors.As(chain, &unwrapper) {
+		t.Fatal("As could not find an error implementing Unwrap() error")
+	}
+	if nil == unwrapper {
+		t.Error("As reported a match but left the target nil")
+	}
+
+	var absent interface{ NotImplementedByAnything() }
+	if errors.As(chain, &absent) {
+		t.Error("As matched an interface nothing implements")
 	}
 }
 
@@ -426,11 +459,19 @@ func TestIsAndAsAgreeWithStdlibAcrossShapes(t *testing.T) {
 				t.Errorf("Is disagreement: std=%v package=%v", std, pkg)
 			}
 			// The same chain, asked for a concrete type instead of a sentinel.
-			var viaStd valueErr
+			// Identical call shape for both, now that the signatures match -- which is itself
+			// the point of the change: the same target works with either function.
+			var viaStd, viaPkg valueErr
 			stdAs := std_errors.As(err, &viaStd)
-			pkgAs := nil != errors.As(err, &valueErr{})
+			pkgAs := errors.As(err, &viaPkg)
 			if stdAs != pkgAs {
 				t.Errorf("As disagreement on valueErr: std=%v package=%v", stdAs, pkgAs)
+			}
+			// A POINTER-receiver type, which the old error-typed target could not express at all.
+			var ptrStd, ptrPkg *custom
+			if std_errors.As(err, &ptrStd) != errors.As(err, &ptrPkg) {
+				t.Errorf("As disagreement on *custom: std=%v package=%v",
+					std_errors.As(err, &ptrStd), errors.As(err, &ptrPkg))
 			}
 		})
 	}

--- a/contract_test.go
+++ b/contract_test.go
@@ -1,0 +1,623 @@
+package errors_test
+
+import (
+	"encoding/json"
+	std_errors "errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/bdlm/errors/v2"
+)
+
+// This file is the package's contract, expressed as tests. It is deliberately organised by
+// OBLIGATION rather than by function, because the obligations are what callers depend on:
+//
+//   1. nothing panics, for any input, including nil receivers and nil arguments
+//   2. a message survives construction verbatim
+//   3. the chain is walkable, and agrees with the standard library at every depth
+//   4. Is and As find what is there and only what is there
+//   5. the rendering paths (Error, Format, MarshalJSON) never lose or invent information
+//
+// doc.go states the package "aims to implement the Error Inspection and Error Values Go2 draft
+// designs" and that "all package methods work with any error type as well as nil values". Those
+// two sentences are the specification these tests hold it to.
+
+var (
+	sentinel = std_errors.New("sentinel")
+	other    = std_errors.New("other")
+)
+
+// custom is a foreign error type: not created by this package, with its own Is hook. Real chains
+// contain these, and they are where an error package's chain walking usually breaks.
+type custom struct{ msg string }
+
+func (c *custom) Error() string { return c.msg }
+
+// valueErr uses a VALUE receiver, so *valueErr is a pointer whose element implements error --
+// the shape bdlm's As(err, test error) requires of its target, and one the standard library's
+// As(err, any) accepts too. It exists so the two can be compared on identical input.
+//
+// Worth noting on its own: bdlm's As signature differs from the standard library's
+// (As(err, test error) error vs As(err error, target any) bool), which is why a target type has to
+// be chosen with both in mind.
+type valueErr struct{ msg string }
+
+func (v valueErr) Error() string { return v.msg }
+
+// customMatching has an Is hook that matches sentinel, the pattern the standard library documents.
+type customMatching struct{}
+
+func (customMatching) Error() string   { return "matches sentinel" }
+func (customMatching) Is(t error) bool { return t == sentinel }
+
+// ---------------------------------------------------------------------------------------------
+// 1. Nothing panics. Every exported entry point, with the inputs a caller can actually supply.
+// ---------------------------------------------------------------------------------------------
+
+func TestNilSafety(t *testing.T) {
+	var nilE *errors.E
+
+	cases := map[string]func(){
+		"New empty":            func() { _ = errors.New("") },
+		"Errorf empty":         func() { _ = errors.Errorf("") },
+		"Wrap nil":             func() { _ = errors.Wrap(nil, "msg") },
+		"Wrap nil empty msg":   func() { _ = errors.Wrap(nil, "") },
+		"WrapE nil nil":        func() { _ = errors.WrapE(nil, nil) },
+		"WrapE err nil":        func() { _ = errors.WrapE(sentinel, nil) },
+		"WrapE nil err":        func() { _ = errors.WrapE(nil, sentinel) },
+		"Unwrap nil":           func() { _ = errors.Unwrap(nil) },
+		"Is nil nil":           func() { _ = errors.Is(nil, nil) },
+		"Is nil target":        func() { _ = errors.Is(sentinel, nil) },
+		"Is nil err":           func() { _ = errors.Is(nil, sentinel) },
+		"As nil nil":           func() { _ = errors.As(nil, nil) },
+		"As nil err":           func() { _ = errors.As(nil, sentinel) },
+		"Caller nil":           func() { _ = errors.Caller(nil) },
+		"Trace nil":            func() { _ = errors.Trace(nil) },
+		"Track nil":            func() { _ = errors.Track(nil) },
+		"nil E Error":          func() { _ = nilE.Error() },
+		"nil E Unwrap":         func() { _ = nilE.Unwrap() },
+		"nil E Caller":         func() { _ = nilE.Caller() },
+		"nil E Is":             func() { _ = nilE.Is(sentinel) },
+		"nil E MarshalJSON":    func() { _, _ = nilE.MarshalJSON() },
+		"nil E format %v":      func() { _ = fmt.Sprintf("%v", nilE) },
+		"nil E format %+v":     func() { _ = fmt.Sprintf("%+v", nilE) },
+		"nil E format %#v":     func() { _ = fmt.Sprintf("%#v", nilE) },
+		"WrapE nil err Error":  func() { _ = errors.WrapE(sentinel, nil).Error() },
+		"WrapE nil err Is":     func() { _ = errors.WrapE(sentinel, nil).Is(sentinel) },
+		"WrapE nil err format": func() { _ = fmt.Sprintf("%+v", errors.WrapE(sentinel, nil)) },
+	}
+	for name, call := range cases {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); nil != r {
+					t.Fatalf("panicked: %v", r)
+				}
+			}()
+			call()
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------------------------
+// 2. A message survives construction verbatim.
+// ---------------------------------------------------------------------------------------------
+
+// TestMessagesAreNotReinterpretedAsFormatStrings: New and Wrap take a MESSAGE. A caller passing a
+// message that happens to contain a percent sign -- a URL-encoded value, a percentage, a Windows
+// path -- must get that message back, not fmt's opinion of it.
+func TestMessagesAreNotReinterpretedAsFormatStrings(t *testing.T) {
+	for _, msg := range []string{
+		"100% complete",
+		"disk usage at 95%",
+		"unexpected %s in input",
+		"query returned %d rows",
+		"literal %% sign",
+	} {
+		t.Run(msg, func(t *testing.T) {
+			if got := errors.New(msg).Error(); msg != got {
+				t.Errorf("New(%q).Error() = %q", msg, got)
+			}
+			if got := errors.Wrap(nil, msg).Error(); msg != got {
+				t.Errorf("Wrap(nil, %q).Error() = %q", msg, got)
+			}
+		})
+	}
+}
+
+// TestErrorfFormats: Errorf is the one that SHOULD interpret its argument as a format string.
+func TestErrorfFormats(t *testing.T) {
+	if got, want := errors.Errorf("%d of %d", 3, 7).Error(), "3 of 7"; want != got {
+		t.Errorf("Errorf = %q, want %q", got, want)
+	}
+	if got, want := errors.Wrap(nil, "%d rows", 42).Error(), "42 rows"; want != got {
+		t.Errorf("Wrap with args = %q, want %q", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------------------------
+// 3. The chain is walkable and agrees with the standard library.
+// ---------------------------------------------------------------------------------------------
+
+// TestUnwrapContract: Unwrap yields the wrapped error ITSELF, so a caller can type-assert it.
+func TestUnwrapContract(t *testing.T) {
+	target := &custom{msg: "foreign"}
+	wrapped := errors.Wrap(target, "outer")
+
+	got := std_errors.Unwrap(wrapped)
+	if got != error(target) {
+		t.Fatalf("Unwrap returned %#v, want the original *custom", got)
+	}
+	if _, ok := got.(*custom); !ok {
+		t.Errorf("Unwrap yielded %T, not the concrete wrapped type", got)
+	}
+	if nil != errors.Unwrap(errors.New("leaf")) {
+		t.Error("a leaf error must unwrap to nil")
+	}
+}
+
+// TestChainDepthAgreesWithStdlib walks a deep mixed chain and requires this package and the
+// standard library to give the same answer at every depth. Mixed on purpose: bdlm frames, a
+// fmt.Errorf frame and a foreign type, which is what real chains look like.
+func TestChainDepthAgreesWithStdlib(t *testing.T) {
+	chain := errors.Wrap(
+		fmt.Errorf("fmt layer: %w",
+			errors.Wrap(
+				errors.WrapE(sentinel, &custom{msg: "foreign"}),
+				"inner bdlm")),
+		"outer bdlm")
+
+	if !std_errors.Is(chain, sentinel) {
+		t.Error("std errors.Is cannot reach the sentinel through the mixed chain")
+	}
+	if !errors.Is(chain, sentinel) {
+		t.Error("package Is cannot reach the sentinel through the mixed chain")
+	}
+	if std_errors.Is(chain, other) != errors.Is(chain, other) {
+		t.Error("package Is and std errors.Is disagree on an absent sentinel")
+	}
+	var target *custom
+	if !std_errors.As(chain, &target) {
+		t.Error("std errors.As cannot reach the foreign type")
+	}
+}
+
+// TestWrappedByFmtIsReachable: fmt.Errorf("%w") of a bdlm error must stay inspectable, since that
+// is how most Go code wraps.
+func TestWrappedByFmtIsReachable(t *testing.T) {
+	inner := errors.Wrap(sentinel, "bdlm frame")
+	outer := fmt.Errorf("fmt frame: %w", inner)
+
+	if !std_errors.Is(outer, sentinel) {
+		t.Error("sentinel unreachable through fmt.Errorf")
+	}
+	var e *errors.E
+	if !std_errors.As(outer, &e) {
+		t.Error("the *E frame is not reachable via std errors.As")
+	}
+}
+
+// ---------------------------------------------------------------------------------------------
+// 4. Is and As find what is there, and only what is there.
+// ---------------------------------------------------------------------------------------------
+
+func TestIsFindsSentinelAtEveryDepth(t *testing.T) {
+	depths := map[string]error{
+		"depth 0": sentinel,
+		"depth 1": errors.Wrap(sentinel, "a"),
+		"depth 2": errors.Wrap(errors.Wrap(sentinel, "a"), "b"),
+		"depth 5": errors.Wrap(errors.Wrap(errors.Wrap(errors.Wrap(errors.Wrap(sentinel, "a"), "b"), "c"), "d"), "e"),
+	}
+	for name, err := range depths {
+		t.Run(name, func(t *testing.T) {
+			if !errors.Is(err, sentinel) {
+				t.Error("package Is missed it")
+			}
+			if !std_errors.Is(err, sentinel) {
+				t.Error("std errors.Is missed it")
+			}
+			if errors.Is(err, other) {
+				t.Error("matched an absent sentinel")
+			}
+		})
+	}
+}
+
+// TestIsRespectsForeignIsHooks: a foreign type's Is hook answering false must NOT end the walk,
+// because the sentinel may still be deeper in the chain.
+func TestIsRespectsForeignIsHooks(t *testing.T) {
+	// customMatching.Is(sentinel) is true -- found via the hook, not by identity.
+	if !errors.Is(errors.Wrap(customMatching{}, "wrapped"), sentinel) {
+		t.Error("a foreign Is hook that matches was not consulted")
+	}
+	// A foreign type whose hook says false must not hide a deeper match. `withFalseIs` wraps the
+	// sentinel and answers false for everything.
+	hidden := errors.Wrap(&falseIs{inner: sentinel}, "wrapped")
+	if !std_errors.Is(hidden, sentinel) {
+		t.Fatal("premise: std errors.Is should reach it via Unwrap")
+	}
+	if !errors.Is(hidden, sentinel) {
+		t.Error("a foreign Is hook answering false ended the walk and hid a deeper match")
+	}
+}
+
+// falseIs answers false to every Is while still wrapping a real cause.
+type falseIs struct{ inner error }
+
+func (f *falseIs) Error() string { return "false-is: " + f.inner.Error() }
+func (f *falseIs) Is(error) bool { return false }
+func (f *falseIs) Unwrap() error { return f.inner }
+
+func TestAsTargets(t *testing.T) {
+	chain := errors.Wrap(errors.Wrap(&custom{msg: "found me"}, "a"), "b")
+
+	var concrete *custom
+	if !std_errors.As(chain, &concrete) || "found me" != concrete.msg {
+		t.Error("std errors.As could not reach the concrete foreign type")
+	}
+
+	var self *errors.E
+	if !std_errors.As(chain, &self) {
+		t.Error("std errors.As could not match *E itself")
+	}
+
+	var absent *falseIs
+	if std_errors.As(chain, &absent) {
+		t.Error("As matched a type that is not in the chain")
+	}
+}
+
+// TestAsRejectsInvalidTargets: the package's own As must not panic on a target the standard
+// library would reject outright.
+func TestAsRejectsInvalidTargets(t *testing.T) {
+	defer func() {
+		if r := recover(); nil != r {
+			t.Fatalf("panicked on an invalid target: %v", r)
+		}
+	}()
+	if nil != errors.As(errors.New("x"), nil) {
+		t.Error("As with a nil target should find nothing")
+	}
+	if nil != errors.As(errors.New("x"), sentinel) {
+		t.Error("As with a non-pointer target should find nothing")
+	}
+}
+
+// ---------------------------------------------------------------------------------------------
+// 5. The rendering paths never lose or invent information.
+// ---------------------------------------------------------------------------------------------
+
+// TestErrorIncludesTheWholeChain: Error() is what an HTTP or gRPC body carries, so a cause
+// recorded one link down must not be silently dropped.
+func TestErrorIncludesTheWholeChain(t *testing.T) {
+	err := errors.Wrap(errors.Wrap(sentinel, "middle"), "outer")
+	got := err.Error()
+	for _, want := range []string{"outer", "middle", "sentinel"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Error() = %q, missing %q", got, want)
+		}
+	}
+}
+
+// TestFormatVerbs: every documented verb produces something, none panics, and the trace verbs
+// include more than the plain ones.
+func TestFormatVerbs(t *testing.T) {
+	err := errors.Wrap(errors.Wrap(sentinel, "middle"), "outer")
+	for _, verb := range []string{"%s", "%v", "%q", "%-v", "%+v", "%#v", "%#+v", "% +v"} {
+		t.Run(verb, func(t *testing.T) {
+			out := fmt.Sprintf(verb, err)
+			if "" == out {
+				t.Errorf("%s produced nothing", verb)
+			}
+			if strings.Contains(out, "%!") {
+				t.Errorf("%s produced a formatting error: %q", verb, out)
+			}
+		})
+	}
+	if plain, trace := fmt.Sprintf("%v", err), fmt.Sprintf("%+v", err); len(trace) <= len(plain) {
+		t.Errorf("%%+v (%d bytes) should carry more than %%v (%d bytes)", len(trace), len(plain))
+	}
+}
+
+// TestMarshalJSONWithForeignWrapperInChain: a chain containing a non-*E error that itself wraps
+// -- fmt.Errorf("%w") being the common case -- must marshal, not panic.
+func TestMarshalJSONWithForeignWrapperInChain(t *testing.T) {
+	defer func() {
+		if r := recover(); nil != r {
+			t.Fatalf("MarshalJSON panicked on a foreign wrapper in the chain: %v", r)
+		}
+	}()
+	err := errors.Wrap(fmt.Errorf("fmt wrapper: %w", sentinel), "outer")
+	raw, marshalErr := json.Marshal(err)
+	if nil != marshalErr {
+		t.Fatalf("marshal: %v", marshalErr)
+	}
+	var entries []map[string]interface{}
+	if err := json.Unmarshal(raw, &entries); nil != err {
+		t.Fatalf("result is not the documented array shape: %v", err)
+	}
+	if 0 == len(entries) {
+		t.Error("marshalled to an empty array")
+	}
+}
+
+func TestMarshalJSONShape(t *testing.T) {
+	raw, err := json.Marshal(errors.Wrap(errors.New("inner"), "outer"))
+	if nil != err {
+		t.Fatalf("marshal: %v", err)
+	}
+	var entries []map[string]interface{}
+	if err := json.Unmarshal(raw, &entries); nil != err {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if 2 > len(entries) {
+		t.Fatalf("entries = %d, want at least 2 (one per frame): %s", len(entries), raw)
+	}
+	for i, entry := range entries {
+		if _, ok := entry["caller"]; !ok {
+			t.Errorf("entry %d has no caller", i)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------------------------
+// 6. Caller data is captured, and points at the caller rather than into this package.
+// ---------------------------------------------------------------------------------------------
+
+func TestCallerPointsAtTheCallSite(t *testing.T) {
+	err := errors.New("here")
+	clr := errors.Caller(err)
+	if nil == clr {
+		t.Fatal("no caller recorded")
+	}
+	if !strings.Contains(clr.File(), "contract_test.go") {
+		t.Errorf("caller file = %q, want this test file", clr.File())
+	}
+	if 0 == clr.Line() {
+		t.Error("caller line is zero")
+	}
+}
+
+func TestTraceAndTrackPreserveTheChain(t *testing.T) {
+	for name, build := range map[string]func(error) error{
+		"Trace": func(e error) error { return errors.Trace(e) },
+		"Track": func(e error) error { return errors.Track(e) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			out := build(errors.Wrap(sentinel, "inner"))
+			if !std_errors.Is(out, sentinel) {
+				t.Error("the sentinel is no longer reachable")
+			}
+			if "" == out.Error() {
+				t.Error("message lost")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------------------------
+// 7. Is and As agree with the standard library as a PROPERTY, across chain shapes, rather than in
+//    a handful of hand-picked cases. Disagreement is the failure mode that matters: a caller
+//    cannot tell which of the two functions to trust.
+// ---------------------------------------------------------------------------------------------
+
+func TestIsAndAsAgreeWithStdlibAcrossShapes(t *testing.T) {
+	shapes := map[string]error{
+		"bare sentinel":            sentinel,
+		"wrapped once":             errors.Wrap(sentinel, "a"),
+		"wrapped twice":            errors.Wrap(errors.Wrap(sentinel, "a"), "b"),
+		"annotated with foreign":   errors.WrapE(sentinel, &custom{msg: "ann"}),
+		"fmt over bdlm":            fmt.Errorf("f: %w", errors.Wrap(sentinel, "a")),
+		"bdlm over fmt":            errors.Wrap(fmt.Errorf("f: %w", sentinel), "a"),
+		"joined":                   std_errors.Join(other, sentinel),
+		"bdlm over joined":         errors.Wrap(std_errors.Join(other, sentinel), "a"),
+		"joined over bdlm":         std_errors.Join(other, errors.Wrap(sentinel, "a")),
+		"nested joins":             std_errors.Join(other, std_errors.Join(other, sentinel)),
+		"traced":                   errors.Trace(errors.Wrap(sentinel, "a")),
+		"tracked":                  errors.Track(errors.Wrap(sentinel, "a")),
+		"foreign hiding the cause": errors.Wrap(&falseIs{inner: sentinel}, "a"),
+		"absent, wrapped":          errors.Wrap(other, "a"),
+		"absent, deep":             errors.Wrap(errors.Wrap(errors.Wrap(other, "a"), "b"), "c"),
+	}
+	for name, err := range shapes {
+		t.Run(name, func(t *testing.T) {
+			std, pkg := std_errors.Is(err, sentinel), errors.Is(err, sentinel)
+			if std != pkg {
+				t.Errorf("Is disagreement: std=%v package=%v", std, pkg)
+			}
+			// The same chain, asked for a concrete type instead of a sentinel.
+			var viaStd valueErr
+			stdAs := std_errors.As(err, &viaStd)
+			pkgAs := nil != errors.As(err, &valueErr{})
+			if stdAs != pkgAs {
+				t.Errorf("As disagreement on valueErr: std=%v package=%v", stdAs, pkgAs)
+			}
+		})
+	}
+}
+
+// TestSentinelIsFoundWhereItIsAndNotWhereItIsNot: the shapes above assert agreement; this asserts
+// the answers are actually CORRECT, so both could not be wrong together.
+func TestSentinelIsFoundWhereItIsAndNotWhereItIsNot(t *testing.T) {
+	present := []error{
+		errors.Wrap(sentinel, "a"),
+		errors.WrapE(sentinel, &custom{msg: "ann"}),
+		errors.Wrap(std_errors.Join(other, sentinel), "a"),
+		errors.Trace(errors.Wrap(sentinel, "a")),
+		errors.Track(errors.Wrap(sentinel, "a")),
+		errors.Wrap(&falseIs{inner: sentinel}, "a"),
+	}
+	for i, err := range present {
+		if !errors.Is(err, sentinel) {
+			t.Errorf("present[%d]: sentinel not found in %v", i, err)
+		}
+	}
+	absent := []error{
+		errors.New("unrelated"),
+		errors.Wrap(other, "a"),
+		errors.Wrap(errors.Wrap(other, "a"), "b"),
+		std_errors.Join(other, other),
+	}
+	for i, err := range absent {
+		if errors.Is(err, sentinel) {
+			t.Errorf("absent[%d]: sentinel found where it is not: %v", i, err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------------------------
+// 8. Robustness: depth, and the rendering paths over a multi-error.
+// ---------------------------------------------------------------------------------------------
+
+// TestDeepChainDoesNotExhaustTheStack: Error, Is and the formatters all recurse, and a wrapped
+// error can accumulate a frame per call-stack level in a long-running service.
+func TestDeepChainDoesNotExhaustTheStack(t *testing.T) {
+	var err error = sentinel
+	for i := 0; i < 2000; i++ {
+		err = errors.Wrap(err, fmt.Sprintf("frame %d", i))
+	}
+	if !errors.Is(err, sentinel) {
+		t.Error("sentinel unreachable at depth 2000")
+	}
+	if !std_errors.Is(err, sentinel) {
+		t.Error("std errors.Is could not reach depth 2000")
+	}
+	if "" == err.Error() {
+		t.Error("Error() produced nothing at depth 2000")
+	}
+	if out := fmt.Sprintf("%+v", err); "" == out {
+		t.Error("the trace verb produced nothing at depth 2000")
+	}
+	if _, marshalErr := json.Marshal(err); nil != marshalErr {
+		t.Errorf("marshal at depth 2000: %v", marshalErr)
+	}
+}
+
+// TestRenderingAMultiError: a joined error has no single previous error, so the single-Unwrap
+// rendering paths must still produce something sensible rather than dropping the branches or
+// panicking.
+func TestRenderingAMultiError(t *testing.T) {
+	err := errors.Wrap(std_errors.Join(other, sentinel), "outer")
+
+	if got := err.Error(); !strings.Contains(got, "outer") {
+		t.Errorf("Error() lost its own message: %q", got)
+	}
+	for _, verb := range []string{"%v", "%+v", "%#v"} {
+		out := fmt.Sprintf(verb, err)
+		if "" == out || strings.Contains(out, "%!") {
+			t.Errorf("verb %s over a multi-error produced %q", verb, out)
+		}
+	}
+	if _, marshalErr := json.Marshal(err); nil != marshalErr {
+		t.Errorf("marshal over a multi-error: %v", marshalErr)
+	}
+}
+
+// ---------------------------------------------------------------------------------------------
+// 9. Concurrency. An error value is shared freely once created -- returned up a stack, logged on
+//    one goroutine while inspected on another -- so reads must not mutate it. Run with -race.
+// ---------------------------------------------------------------------------------------------
+
+func TestConcurrentReadsAreSafe(t *testing.T) {
+	err := errors.Wrap(errors.Wrap(sentinel, "middle"), "outer")
+	const workers = 32
+	done := make(chan struct{}, workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			for j := 0; j < 50; j++ {
+				_ = err.Error()
+				_ = errors.Is(err, sentinel)
+				_ = std_errors.Is(err, sentinel)
+				_ = fmt.Sprintf("%+v", err)
+				_, _ = json.Marshal(err)
+				_ = errors.Unwrap(err)
+				_ = errors.Caller(err)
+			}
+		}()
+	}
+	for i := 0; i < workers; i++ {
+		<-done
+	}
+}
+
+// ---------------------------------------------------------------------------------------------
+// 10. The branches a happy-path test never reaches: foreign inputs to the decorators, and frames
+//     that carry nothing.
+// ---------------------------------------------------------------------------------------------
+
+// withCaller is a foreign error that already carries caller data, which Trace and Track are
+// documented to adopt rather than discard.
+type withCaller struct{ inner error }
+
+func (w *withCaller) Error() string { return w.inner.Error() }
+func (w *withCaller) Unwrap() error { return w.inner }
+
+func TestDecoratorsAcceptForeignErrors(t *testing.T) {
+	cases := map[string]error{
+		"plain stdlib error": sentinel,
+		"foreign type":       &custom{msg: "foreign"},
+		"foreign that wraps": &withCaller{inner: sentinel},
+		"fmt wrapped":        fmt.Errorf("f: %w", sentinel),
+		"joined":             std_errors.Join(other, sentinel),
+	}
+	for name, input := range cases {
+		t.Run("Trace/"+name, func(t *testing.T) {
+			out := errors.Trace(input)
+			if nil == out {
+				t.Fatal("Trace returned nil for a non-nil error")
+			}
+			if "" == out.Error() {
+				t.Error("Trace lost the message")
+			}
+			if !std_errors.Is(out, sentinel) && !std_errors.Is(input, sentinel) {
+				return // the input genuinely has no sentinel
+			}
+			if !std_errors.Is(out, sentinel) {
+				t.Error("Trace severed the chain")
+			}
+		})
+		t.Run("Track/"+name, func(t *testing.T) {
+			out := errors.Track(input)
+			if nil == out {
+				t.Fatal("Track returned nil for a non-nil error")
+			}
+			if "" == out.Error() {
+				t.Error("Track lost the message")
+			}
+			if std_errors.Is(input, sentinel) && !std_errors.Is(out, sentinel) {
+				t.Error("Track severed the chain")
+			}
+		})
+	}
+}
+
+// TestFrameWithNoMessageIsTransparent: a frame can exist purely to add caller data. It must not
+// contribute an empty segment, a stray separator, or swallow what it wraps.
+func TestFrameWithNoMessageIsTransparent(t *testing.T) {
+	if got := errors.WrapE(nil, nil).Error(); "" != got {
+		t.Errorf("an empty frame rendered %q, want the empty string", got)
+	}
+	if got, want := errors.WrapE(sentinel, nil).Error(), sentinel.Error(); want != got {
+		t.Errorf("a frame with no annotation rendered %q, want %q", got, want)
+	}
+	traced := errors.Trace(errors.Wrap(sentinel, "inner"))
+	if got := traced.Error(); strings.HasPrefix(got, ":") || strings.Contains(got, ": :") {
+		t.Errorf("Trace introduced an empty segment: %q", got)
+	}
+	if got, want := traced.Error(), "inner: sentinel"; want != got {
+		t.Errorf("Trace changed the rendered message: %q, want %q", got, want)
+	}
+}
+
+// TestErrorfAndNewAreDistinct pins the one difference between them, since it is the whole reason
+// both exist: Errorf interprets, New does not.
+func TestErrorfAndNewAreDistinct(t *testing.T) {
+	const raw = "50% of %d"
+	if got := errors.New(raw).Error(); raw != got {
+		t.Errorf("New must not interpret: got %q", got)
+	}
+	if got, want := errors.Errorf("50%% of %d", 8).Error(), "50% of 8"; want != got {
+		t.Errorf("Errorf must interpret: got %q, want %q", got, want)
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -29,11 +29,19 @@ Install
 
 	go get github.com/bdlm/errors/v2
 
-Quick Start
+# Quick Start
 
-All package methods work with any `error` type as well as `nil` values, and error instances
-implement the Unwrap, Is, Marshaler, and Formatter interfaces as well as the github.com/bdlm/std/errors
-interfaces.
+All package methods work with any `error` type as well as `nil` values -- including a nil *E
+receiver -- and error instances implement the Unwrap, Is, As, Marshaler, and Formatter interfaces as
+well as the github.com/bdlm/std/errors interfaces.
+
+Two guarantees are worth stating explicitly, because both are load-bearing and both are covered by
+tests: nothing in this package panics, for any combination of nil arguments and nil receivers; and
+Is and As agree with the standard library's Is and As on every chain shape, so it never matters
+which of the two a caller reaches for.
+
+New and Wrap take a MESSAGE, stored verbatim. Only Errorf, and Wrap when given arguments, treat it
+as a format string -- so a message containing a percent sign survives intact.
 
 Create an error:
 
@@ -43,20 +51,20 @@ Create an error using formatting verbs:
 
 	var MyError = errors.Errorf("My error #%d", 1)
 
-
 Wrap an error:
 
 	if nil != err {
 		return errors.Wrap(err, "the operation failed")
 	}
 
-Wrap an error with another error:
+Wrap an error with another error. Note this is WrapE: Wrap takes a message string, so passing an
+error to it does not compile.
 
 	err := try1()
 	if nil != err {
 		err2 := try2()
 		if nil != err2 {
-			return errors.Wrap(err, err2)
+			return errors.WrapE(err, err2)
 		}
 		return err
 	}
@@ -78,15 +86,9 @@ Test for a specific error type:
 		}
 	}
 
-Test to see if a specific error type exists anywhere in an error stack:
-
-	var MyError = errors.New("My error")
-	func main() {
-		err := doWork()
-		if errors.Has(err, MyError) {
-			...
-		}
-	}
+Is searches the whole chain, so there is no separate Has: the test above answers "does this
+error, or anything it wraps, match" -- at any depth, through fmt.Errorf("%w") wrappers, foreign
+error types and joined errors alike.
 
 Iterate through an error stack:
 

--- a/doc.go
+++ b/doc.go
@@ -86,6 +86,18 @@ Test for a specific error type:
 		}
 	}
 
+Find a specific error type anywhere in a chain:
+
+	var target *MyErrorType
+	if errors.As(err, &target) {
+		...
+	}
+
+As takes the same arguments as the standard library's, target being a pointer to the type or
+interface being looked for, and returns whether one was found. It panics if target is not a non-nil
+pointer to either a type implementing error or to any interface type -- an unusable target is a
+mistake at the call site, not a condition to report.
+
 Is searches the whole chain, so there is no separate Has: the test above answers "does this
 error, or anything it wraps, match" -- at any depth, through fmt.Errorf("%w") wrappers, foreign
 error types and joined errors alike.

--- a/error.go
+++ b/error.go
@@ -1,7 +1,7 @@
 package errors
 
 import (
-	"reflect"
+	std_errors "errors"
 
 	std_caller "github.com/bdlm/std/v2/caller"
 	std_error "github.com/bdlm/std/v2/errors"
@@ -31,8 +31,17 @@ func (e *E) Caller() std_caller.Caller {
 // HTTP or gRPC response body. A caller was told "unable to resolve the signing key" with no hint of
 // the cause that was already recorded one link down.
 func (e *E) Error() string {
-	if nil == e.err {
+	if nil == e {
 		return ""
+	}
+	// A frame can legitimately carry no message of its own: Trace adds caller data without
+	// annotating, and WrapE accepts a nil annotation. Such a frame must be transparent rather
+	// than swallowing the chain or emitting a leading ": ".
+	if nil == e.err {
+		if nil == e.prev {
+			return ""
+		}
+		return e.prev.Error()
 	}
 	if nil == e.prev {
 		return e.err.Error()
@@ -54,26 +63,22 @@ func (e *E) message() string {
 
 // Is implements std_error.Error.
 func (e *E) Is(test error) bool {
-	if nil == test {
+	if nil == e || nil == test {
 		return false
 	}
 
-	isComparable := reflect.TypeOf(e).Comparable() && reflect.TypeOf(test).Comparable()
-	if isComparable && e == test {
+	if comparableErrors(e, test) && error(e) == test {
 		return true
 	}
-	isComparable = reflect.TypeOf(e.err).Comparable() && reflect.TypeOf(test).Comparable()
-	if isComparable && e.err == test {
+	if comparableErrors(e.err, test) && e.err == test {
 		return true
 	}
 
 	if testE, ok := test.(*E); ok {
-		isComparable = reflect.TypeOf(e).Comparable() && reflect.TypeOf(testE).Comparable()
-		if isComparable && e == testE {
+		if comparableErrors(e, testE) && error(e) == error(testE) {
 			return true
 		}
-		isComparable = reflect.TypeOf(e.err).Comparable() && reflect.TypeOf(testE.err).Comparable()
-		if isComparable && e.err == testE.err {
+		if comparableErrors(e.err, testE.err) && e.err == testE.err {
 			return true
 		}
 	}
@@ -93,6 +98,23 @@ func (e *E) Is(test error) bool {
 	}
 
 	return false
+}
+
+// As implements the standard library's As hook, interface{ As(interface{}) bool }, which
+// errors.As consults on each link before unwrapping.
+//
+// It exists because WrapE puts its annotation in e.err, which is NOT on the Unwrap chain -- Unwrap
+// yields e.prev. Is already special-cases e.err, so without this hook Is could find an error that
+// As could not, and a caller had no way to know which of the two would work. For an error package
+// the two must agree about what is in the chain.
+//
+// Delegating to the standard library rather than comparing types by hand also searches the
+// annotation's OWN chain, which is what errors.As would have done had the value been reachable.
+func (e *E) As(target interface{}) bool {
+	if nil == e || nil == e.err || nil == target {
+		return false
+	}
+	return std_errors.As(e.err, target)
 }
 
 // Unwrap implements std_error.Wrapper.

--- a/export.go
+++ b/export.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	std_errors "errors"
 	"fmt"
 	"reflect"
 
@@ -9,6 +10,16 @@ import (
 )
 
 var errorType = reflect.TypeOf((*error)(nil)).Elem()
+
+// comparableErrors reports whether == is defined for both operands.
+//
+// reflect.TypeOf(nil) returns a NIL reflect.Type, and calling Comparable on that panics rather than
+// answering false. A nil operand is ordinary here -- a frame can carry no annotation of its own --
+// so every comparability check has to screen for it first.
+func comparableErrors(a, b error) bool {
+	ta, tb := reflect.TypeOf(a), reflect.TypeOf(b)
+	return nil != ta && nil != tb && ta.Comparable() && tb.Comparable()
+}
 
 // As searches the error stack for an error that can be cast to the test
 // argument, which must be a pointer. If it succeeds it performs the
@@ -36,6 +47,14 @@ func As(err, test error) error {
 		}
 		if e, ok := err.(interface{ As(error) error }); ok {
 			return e.As(test)
+		}
+		// An *E's annotation (e.err) is not on the Unwrap chain -- Unwrap yields e.prev -- so it
+		// has to be searched explicitly, exactly as Is does. Without this the package's own As
+		// disagreed with its Is about what the chain contains.
+		if e, ok := err.(*E); ok && nil != e.err {
+			if found := As(e.err, test); nil != found {
+				return found
+			}
 		}
 		// Same multi-error branch as Is, for the same reason: Unwrap cannot express Unwrap() []error,
 		// so the walk would terminate at a join and miss every cause below it.
@@ -87,14 +106,16 @@ func Is(err, test error) bool {
 		return false
 	}
 
-	isComparable := reflect.TypeOf(err).Comparable() && reflect.TypeOf(test).Comparable()
-	if isComparable && err == test {
+	if comparableErrors(err, test) && err == test {
 		return true
 	}
 
+	// The annotation slot, which is not on the Unwrap chain -- see (*E).As. Note e.err can be nil
+	// (Trace annotates nothing), which is why this goes through comparableErrors rather than
+	// calling reflect.TypeOf(...).Comparable() directly: reflect.TypeOf(nil) is a NIL Type and
+	// calling any method on it panics.
 	if e, ok := err.(*E); ok {
-		isComparable := reflect.TypeOf(e.err).Comparable() && reflect.TypeOf(test).Comparable()
-		if isComparable && e.err == test {
+		if comparableErrors(e.err, test) && e.err == test {
 			return true
 		}
 	}
@@ -130,10 +151,15 @@ func Is(err, test error) bool {
 }
 
 // New returns an error that contains caller data.
+//
+// msg is a MESSAGE, not a format string: it is stored verbatim. Passing it through fmt.Errorf
+// corrupted any message containing a percent sign -- New("100% complete") produced
+// "100%!c(MISSING)omplete", and "disk usage at 95%" produced "...95%!(NOVERB)". Callers that want
+// formatting have Errorf.
 func New(msg string) *E {
 	return &E{
 		caller: NewCaller(),
-		err:    fmt.Errorf(msg),
+		err:    std_errors.New(msg),
 	}
 }
 
@@ -150,38 +176,43 @@ func Trace(e error) *E {
 		clr.trace = append(clr.trace, stdClr.Caller().Trace()...)
 	}
 
+	// prev, NOT err. Trace adds a caller line; it does not annotate. Holding the wrapped error in
+	// the message slot left prev nil, so Unwrap returned nothing and the whole chain below the
+	// trace became unreachable -- errors.Is could no longer find a sentinel through it. Error()
+	// treats a frame with no message of its own as transparent, so the rendered text is unchanged.
 	return &E{
 		caller: clr,
-		err:    e,
+		prev:   e,
 	}
 }
 
 // Track updates the error stack with additional caller data.
+//
+// The tracked error stays ON THE UNWRAP CHAIN. It was previously held in the annotation slot with
+// prev taken from a synthetic box, so for anything other than an *E -- a fmt.Errorf("%w") wrapper, a
+// joined error, any foreign type that wraps -- prev was nil and everything the error itself wrapped
+// became unreachable: errors.Is could no longer find a sentinel through it. A decorator that adds
+// caller data must not cost the caller their chain.
+//
+// The inserted frame's message is the marker alone rather than the error's text repeated, since the
+// error it wraps renders immediately after it.
 func Track(e error) *E {
-	var stdE *E
 	if nil == e {
 		return nil
 	}
 
-	stdE, ok := e.(*E)
-	if !ok {
-		stdE = &E{
-			err: e,
-		}
-		if clr, ok := e.(std_error.Caller); ok {
-			stdE.caller = clr.Caller()
-		} else {
-			stdE.caller = NewCaller()
-		}
+	// Adopt the error's own caller when it has one, so tracking does not overwrite the origin.
+	clr := NewCaller()
+	if stdClr, ok := e.(std_error.Caller); ok && nil != stdClr.Caller() {
+		clr = stdClr.Caller()
 	}
 
 	return &E{
-		caller: stdE.Caller(),
-		err:    e,
+		caller: clr,
 		prev: &E{
 			caller: NewCaller(),
-			err:    fmt.Errorf("%s (tracked)", e),
-			prev:   stdE.Unwrap(),
+			err:    std_errors.New("(tracked)"),
+			prev:   e,
 		},
 	}
 }
@@ -199,7 +230,14 @@ func Unwrap(err error) error {
 }
 
 // Wrap returns a new error that wraps the provided error.
+//
+// msg is treated as a format string ONLY when data is supplied, matching New/Errorf: with no
+// arguments there is nothing to interpolate, and interpreting it anyway corrupts any message
+// containing a percent sign.
 func Wrap(e error, msg string, data ...interface{}) *E {
+	if 0 == len(data) {
+		return WrapE(e, std_errors.New(msg))
+	}
 	return WrapE(e, fmt.Errorf(msg, data...))
 }
 

--- a/export.go
+++ b/export.go
@@ -23,53 +23,66 @@ func comparableErrors(a, b error) bool {
 
 // As searches the error stack for an error that can be cast to the test
 // argument, which must be a pointer. If it succeeds it performs the
-// assignment and returns the result, otherwise it returns nil.
-func As(err, test error) error {
-	if nil == err || nil == test {
-		return nil
+// As finds the first error in err's chain that matches target, and if one is found, sets target to
+// that error value and returns true. Otherwise it returns false.
+//
+// The chain consists of err itself followed by the errors obtained by repeatedly unwrapping it. An
+// error matches target if the error's concrete type is assignable to the value pointed to by
+// target, or if the error has a method As(interface{}) bool such that As(target) returns true.
+//
+// As panics if target is not a non-nil pointer to either a type that implements error, or to any
+// interface type. That is deliberate and matches the standard library: an unusable target is a
+// programming error at the call site, not a runtime condition to be reported, and returning false
+// for it would silently hide the mistake in exactly the code paths that are hardest to observe.
+//
+// SIGNATURE CHANGE. This previously read As(err, test error) error, returning the matched error or
+// nil. That forced the target to satisfy the error interface, so a caller could not ask for a bare
+// interface type and had to choose between a value and a pointer receiver purely to make the call
+// compile. It also meant this package's central helper did not match the standard library it aims
+// to implement, so code moving between the two had to change shape.
+func As(err error, target interface{}) bool {
+	if nil == err {
+		return false
 	}
-
-	val := reflect.ValueOf(test)
+	if nil == target {
+		panic("errors: target cannot be nil")
+	}
+	val := reflect.ValueOf(target)
 	typ := val.Type()
-	if typ.Kind() != reflect.Ptr || val.IsNil() {
-		return nil
+	if reflect.Ptr != typ.Kind() || val.IsNil() {
+		panic("errors: target must be a non-nil pointer")
+	}
+	targetType := typ.Elem()
+	if reflect.Interface != targetType.Kind() && !targetType.Implements(errorType) {
+		panic("errors: *target must be interface or implement error")
 	}
 
-	if e := typ.Elem(); e.Kind() != reflect.Interface && !e.Implements(errorType) {
-		return nil
-	}
-
-	testType := typ.Elem()
-	for err != nil {
-		if reflect.TypeOf(err).AssignableTo(testType) {
+	for {
+		if reflect.TypeOf(err).AssignableTo(targetType) {
 			val.Elem().Set(reflect.ValueOf(err))
-			return err
+			return true
 		}
-		if e, ok := err.(interface{ As(error) error }); ok {
-			return e.As(test)
+		// `ok && x.As(target)`, not a bare return: a hook answering false means THIS link does not
+		// match, not that the search is over. (*E) implements this hook, and it is what reaches the
+		// annotation slot -- which is not on the Unwrap chain -- so Is and As agree about the chain.
+		if x, ok := err.(interface{ As(interface{}) bool }); ok && x.As(target) {
+			return true
 		}
-		// An *E's annotation (e.err) is not on the Unwrap chain -- Unwrap yields e.prev -- so it
-		// has to be searched explicitly, exactly as Is does. Without this the package's own As
-		// disagreed with its Is about what the chain contains.
-		if e, ok := err.(*E); ok && nil != e.err {
-			if found := As(e.err, test); nil != found {
-				return found
-			}
-		}
-		// Same multi-error branch as Is, for the same reason: Unwrap cannot express Unwrap() []error,
-		// so the walk would terminate at a join and miss every cause below it.
+		// An error may wrap SEVERAL causes -- errors.Join, or fmt.Errorf with more than one %w --
+		// and Unwrap() []error cannot be expressed by the single-error Unwrap below, so without this
+		// branch the walk stops at the join and every cause underneath is unreachable.
 		if multi, ok := err.(interface{ Unwrap() []error }); ok {
 			for _, branch := range multi.Unwrap() {
-				if found := As(branch, test); nil != found {
-					return found
+				if nil != branch && As(branch, target) {
+					return true
 				}
 			}
-			return nil
+			return false
 		}
-		err = Unwrap(err)
+		if err = Unwrap(err); nil == err {
+			return false
+		}
 	}
-
-	return nil
 }
 
 // Caller returns the Caller associated with an error, if any.

--- a/marshal.go
+++ b/marshal.go
@@ -9,6 +9,9 @@ import (
 
 // MarshalJSON implements the json.Marshaller interface.
 func (e *E) MarshalJSON() ([]byte, error) {
+	if nil == e {
+		return []byte("null"), nil
+	}
 	var lastE, nextE error
 	var key int
 	jsonData := []map[string]interface{}{}
@@ -28,11 +31,19 @@ func (e *E) MarshalJSON() ([]byte, error) {
 				key,
 			)
 		}
-		lastE = err.prev
+		// Guarded on ok: list() includes ANY error implementing Unwrap() error, so a foreign
+		// wrapper in the chain -- fmt.Errorf("%w") being the common one -- lands here with err
+		// nil, and reading err.prev panicked. Marshalling an error must never panic; that is the
+		// path a logger takes while already handling a failure.
+		if ok {
+			lastE = err.prev
+		} else {
+			lastE = nil
+		}
 		// frameMessage, not Error(): each entry is one frame, and Error() now carries the wrapped
 		// chain -- so using it here would repeat the whole tail in every entry of the array.
 		if "" != frameMessage(nextE) {
-			data["error"] = frameMessage(err)
+			data["error"] = frameMessage(nextE)
 		}
 		jsonData = append(jsonData, data)
 	}

--- a/multierror_test.go
+++ b/multierror_test.go
@@ -14,7 +14,7 @@ var (
 )
 
 // customErr uses a VALUE receiver so that *customErr is a pointer whose element type implements
-// error, which is the shape bdlm's As(err, test error) requires of its target.
+// error. Both receiver kinds must work as an As target.
 type customErr struct{ msg string }
 
 func (c customErr) Error() string { return c.msg }
@@ -78,9 +78,9 @@ func TestAsTraversesMultiErrors(t *testing.T) {
 			t.Fatalf("%s: premise broken, std_errors.As cannot find it either", name)
 		}
 
-		found := &customErr{}
-		if got := errors.As(err, found); nil == got || cause.msg != found.msg {
-			t.Errorf("%s: As did not reach the concrete cause (got %v, found %q)", name, got, found.msg)
+		var found customErr
+		if !errors.As(err, &found) || cause.msg != found.msg {
+			t.Errorf("%s: As did not reach the concrete cause (found %q)", name, found.msg)
 		}
 	}
 }


### PR DESCRIPTION
As becomes As(err error, target interface{}) bool, replacing
As(err, test error) error. This is a breaking API change, hence v2.2.0.

The old form required the target to satisfy error, and that had two costs. A
caller could not ask for a bare interface type at all -- an interface pointer
does not itself implement error -- which is the most common real question to ask
of a chain: does anything in here implement this behaviour. And for concrete
types the target's receiver kind leaked into the call site: a type with a
pointer receiver could not be asked for, so callers chose value receivers to
make the call compile rather than because the type wanted one. This package's
own test helpers had done exactly that.

It also meant the central helper of a package that aims to implement the Go2
error inspection design did not match the standard library it mirrors, so code
moving between errors.As and bdlm/errors.As had to change shape as well as
import path.

Two behaviours now match the standard library exactly. As panics on a target
that is not a non-nil pointer to an error-implementing type or to an interface:
such a target can never match anything, so answering "not found" would hide a
call-site mistake in the paths hardest to observe. A nil ERROR remains an
ordinary false, which is the opposite case -- a runtime condition rather than a
programming error, and the standard library draws the same line.

The walk also no longer ends on a hook that answers false. It read
`if e, ok := err.(interface{ As(error) error }); ok { return e.As(test) }`, so
the first link with an As method decided the whole search -- the same defect
that was fixed in Is, in the same shape. It is now `ok && x.As(target)`.

Tests cover the panic contract across four unusable target shapes, interface
targets, pointer- and value-receiver concrete targets, and agreement with the
standard library on every chain shape using an identical call for both -- which
is itself the point of the change. Coverage 97.3%, vet clean, race clean.

The As(interface{}) bool hook on *E is unchanged and is what reaches the
annotation slot, so Is and As continue to agree about what the chain contains.